### PR TITLE
Enable/disable toggle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>io.github.stealingdapenta</groupId>
     <artifactId>damageindicator</artifactId>
-    <version>1.1.4-SNAPSHOT</version>
+    <version>1.1.5-SNAPSHOT</version>
     <name>damageindicator</name>
     <description>Minecraft Damage Indicator.</description>
 

--- a/src/main/java/io/github/stealingdapenta/damageindicator/ConfigurationFileManager.java
+++ b/src/main/java/io/github/stealingdapenta/damageindicator/ConfigurationFileManager.java
@@ -34,6 +34,23 @@ public class ConfigurationFileManager {
         plugin.saveConfig();
     }
 
+    public boolean getBooleanValue(DefaultConfigValue key) {
+        return getBooleanValue(key.name().toLowerCase());
+    }
+
+    public boolean getBooleanValue(String key) {
+        JavaPlugin plugin = DamageIndicator.getInstance();
+        String valueAsString = plugin.getConfig().getString(key);
+        boolean result;
+        try {
+            result = Boolean.parseBoolean(valueAsString);
+        } catch (NumberFormatException | NullPointerException e) {
+            DamageIndicator.getInstance().getLogger().warning("Error parsing the value in the config file for " + key);
+            result = false;
+        }
+        return result;
+    }
+
     public int getValue(DefaultConfigValue key) {
         return getValue(key.name().toLowerCase());
     }

--- a/src/main/java/io/github/stealingdapenta/damageindicator/DamageIndicator.java
+++ b/src/main/java/io/github/stealingdapenta/damageindicator/DamageIndicator.java
@@ -23,8 +23,8 @@ public class DamageIndicator extends JavaPlugin {
 
         ConfigurationFileManager.getInstance().loadConfig();
 
-        Bukkit.getPluginManager().registerEvents(damageIndicatorListener, getInstance());
-        Bukkit.getPluginManager().registerEvents(healthBarListener, getInstance());
+        enableDamageIndicator();
+        enableHealthBar();
 
         pluginEnabledLog();
     }
@@ -36,8 +36,26 @@ public class DamageIndicator extends JavaPlugin {
         pluginDisabledLog();
     }
 
+    private void enableDamageIndicator() {
+        if (ConfigurationFileManager.getInstance().getBooleanValue(DefaultConfigValue.ENABLE_DAMAGE_INDICATOR)) {
+            Bukkit.getPluginManager().registerEvents(damageIndicatorListener, getInstance());
+            getLogger().info("Damage indicator feature enabled. To disable, modify the config.yml.");
+        } else {
+            getLogger().info("Damage indicator feature not enabled. To enable, modify the config.yml.");
+        }
+    }
+
+    private void enableHealthBar() {
+        if (ConfigurationFileManager.getInstance().getBooleanValue(DefaultConfigValue.ENABLE_HEALTH_BAR)) {
+            Bukkit.getPluginManager().registerEvents(healthBarListener, getInstance());
+            getLogger().info("Health bar feature enabled. To disable, modify the config.yml.");
+        } else {
+            getLogger().info("Health bar feature not enabled. To enable, modify the config.yml.");
+        }
+    }
+
     private void pluginEnabledLog() {
-        getLogger().info("Damage indicator enabled.");
+        getLogger().info("Damage indicator plugin enabled.");
     }
 
     private void pluginDisabledLog() {

--- a/src/main/java/io/github/stealingdapenta/damageindicator/DefaultConfigValue.java
+++ b/src/main/java/io/github/stealingdapenta/damageindicator/DefaultConfigValue.java
@@ -1,12 +1,14 @@
 package io.github.stealingdapenta.damageindicator;
 
 public enum DefaultConfigValue {
+    ENABLE_DAMAGE_INDICATOR("true"),
     MAGIC("(95, 10, 95)"),
     MELEE("(100, 100, 100)"),
     POISON("(0, 100, 20)"),
     FIRE("(200, 90, 25)"),
     RANGED("(130, 70, 0)"),
     OTHER("(130, 130, 30)"),
+    ENABLE_HEALTH_BAR("true"),
     HEALTH_BAR_DISPLAY_DURATION("5"),
     HEALTH_BAR_ALIVE_COLOR("(0, 255, 0)"),
     HEALTH_BAR_DEAD_COLOR("(100, 100, 100)");

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: damageindicator
-version: 1.1.4
+version: 1.1.5
 main: io.github.stealingdapenta.damageindicator.DamageIndicator
 author: StealingDaPenta
 description: The best Damage Indicator in the game!


### PR DESCRIPTION
Adds a configuration value for each feature, with a true/false state.
The said feature will only be enabled if the config returns true for it.
Currently this includes: damage indicator splashes & the health bar.
Default: True.

The state will be printed upon launch, as follows:

![image](https://github.com/TomDesch/damageIndicator/assets/29839170/90170c22-9a29-4ba5-bee5-58ce29c44b75)
