### PR TITLE
Custom Name Compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>io.github.stealingdapenta</groupId>
     <artifactId>damageindicator</artifactId>
-    <version>1.1.6-SNAPSHOT</version>
+    <version>1.1.7-SNAPSHOT</version>
     <name>damageindicator</name>
     <description>Minecraft Damage Indicator.</description>
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: damageindicator
-version: 1.1.6
+version: 1.1.7
 main: io.github.stealingdapenta.damageindicator.DamageIndicator
 author: StealingDaPenta
 description: The best Damage Indicator in the game!


### PR DESCRIPTION
Optimized the way the healthbar is displayed by only running one task to remove it after the given time, instead of checking every tick.

Also: now keeps track of the original entity name, and resets it afterwards.