### PR TITLE
Edit bar style

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>io.github.stealingdapenta</groupId>
     <artifactId>damageindicator</artifactId>
-    <version>1.1.8-SNAPSHOT</version>
+    <version>1.1.9-SNAPSHOT</version>
     <name>damageindicator</name>
     <description>Minecraft Damage Indicator.</description>
 

--- a/src/main/java/io/github/stealingdapenta/damageindicator/ConfigurationFileManager.java
+++ b/src/main/java/io/github/stealingdapenta/damageindicator/ConfigurationFileManager.java
@@ -51,6 +51,10 @@ public class ConfigurationFileManager {
         return result;
     }
 
+    public String getStringValue(DefaultConfigValue key) {
+        return DamageIndicator.getInstance().getConfig().getString(key.name().toLowerCase());
+    }
+
     public int getValue(DefaultConfigValue key) {
         return getValue(key.name().toLowerCase());
     }

--- a/src/main/java/io/github/stealingdapenta/damageindicator/DefaultConfigValue.java
+++ b/src/main/java/io/github/stealingdapenta/damageindicator/DefaultConfigValue.java
@@ -11,7 +11,12 @@ public enum DefaultConfigValue {
     ENABLE_HEALTH_BAR("true"),
     HEALTH_BAR_DISPLAY_DURATION("5"),
     HEALTH_BAR_ALIVE_COLOR("(0, 255, 0)"),
-    HEALTH_BAR_DEAD_COLOR("(100, 100, 100)");
+    HEALTH_BAR_ALIVE_SYMBOL("♥"),
+    HEALTH_BAR_DEAD_COLOR("(100, 100, 100)"),
+    HEALTH_BAR_DEAD_SYMBOL("♡"),
+    HEALTH_BAR_STRIKETHROUGH("true"),
+    HEALTH_BAR_BOLD("true"),
+    HEALTH_BAR_UNDERLINED("false");
 
     private final String defaultValue;
 

--- a/src/main/java/io/github/stealingdapenta/damageindicator/listener/HealthBarListener.java
+++ b/src/main/java/io/github/stealingdapenta/damageindicator/listener/HealthBarListener.java
@@ -88,7 +88,9 @@ public class HealthBarListener implements Listener {
         Component originalName = Objects.nonNull(livingEntity.customName()) ? livingEntity.customName() : livingEntity.name();
         originalEntityNames.put(livingEntity, originalName);
 
-        displayHealthBar(livingEntity, event.getFinalDamage());
+        double currentHealth = Math.max(0, ((LivingEntity) event.getEntity()).getHealth() - event.getFinalDamage());
+
+        displayBar(livingEntity, currentHealth);
     }
 
     @EventHandler(priority = EventPriority.MONITOR)
@@ -116,11 +118,10 @@ public class HealthBarListener implements Listener {
         return TICKS_PER_SECOND * Math.max(MIN_SECONDS, Math.min(displayDuration, MAX_SECONDS));
     }
 
-    private void displayHealthBar(LivingEntity livingEntity, double damageDone) {
-        double health = livingEntity.getHealth() - damageDone;
+    private void displayBar(LivingEntity livingEntity, double currentHealth) {
         double maxHealth = Objects.requireNonNull(livingEntity.getAttribute(Attribute.GENERIC_MAX_HEALTH)).getValue();
 
-        livingEntity.customName(createHealthBar(health, maxHealth));
+        livingEntity.customName(createHealthBar(currentHealth, maxHealth));
         livingEntity.setCustomNameVisible(true);
     }
 

--- a/src/main/java/io/github/stealingdapenta/damageindicator/listener/HealthBarListener.java
+++ b/src/main/java/io/github/stealingdapenta/damageindicator/listener/HealthBarListener.java
@@ -5,11 +5,11 @@ import io.github.stealingdapenta.damageindicator.DamageIndicator;
 import io.github.stealingdapenta.damageindicator.DefaultConfigValue;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
-import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.scheduler.BukkitRunnable;
@@ -18,17 +18,23 @@ import org.bukkit.scheduler.BukkitTask;
 import java.util.HashMap;
 import java.util.Objects;
 
+import static io.github.stealingdapenta.damageindicator.DefaultConfigValue.HEALTH_BAR_ALIVE_COLOR;
+import static io.github.stealingdapenta.damageindicator.DefaultConfigValue.HEALTH_BAR_ALIVE_SYMBOL;
+import static io.github.stealingdapenta.damageindicator.DefaultConfigValue.HEALTH_BAR_DEAD_COLOR;
+import static io.github.stealingdapenta.damageindicator.DefaultConfigValue.HEALTH_BAR_DEAD_SYMBOL;
+import static io.github.stealingdapenta.damageindicator.DefaultConfigValue.HEALTH_BAR_STRIKETHROUGH;
+import static io.github.stealingdapenta.damageindicator.DefaultConfigValue.HEALTH_BAR_UNDERLINED;
+
 public class HealthBarListener implements Listener {
     private static final int TICKS_PER_SECOND = 20;
     private static final int MIN_SECONDS = 1;
     private static final int MAX_SECONDS = 10;
-    private static final String SPACE = " ";
     private final HashMap<LivingEntity, BukkitTask> entitiesWithActiveHealthBars = new HashMap<>();
     private final HashMap<LivingEntity, Component> originalEntityNames = new HashMap<>();
-    private final ConfigurationFileManager configurationFileManager;
+    private final ConfigurationFileManager cfm;
 
     public HealthBarListener() {
-        configurationFileManager = ConfigurationFileManager.getInstance();
+        cfm = ConfigurationFileManager.getInstance();
     }
 
     private Component createHealthBar(double currentHealth, double maxHealth) {
@@ -36,17 +42,37 @@ public class HealthBarListener implements Listener {
         int aliveBarLength = Math.max(0, (int) (percentAlive * 16));
         int deadBarLength = Math.max(0, 16 - aliveBarLength);
 
-        TextComponent aliveComponent = getBoldAndStrikeThroughSpaceLine(aliveBarLength, configurationFileManager.getTextColor(DefaultConfigValue.HEALTH_BAR_ALIVE_COLOR));
-        TextComponent deadComponent = getBoldAndStrikeThroughSpaceLine(deadBarLength, configurationFileManager.getTextColor(DefaultConfigValue.HEALTH_BAR_DEAD_COLOR));
+        TextComponent aliveComponent = buildAliveComponent(aliveBarLength);
+        TextComponent deadComponent = buildDeadComponent(deadBarLength);
 
-        return aliveComponent.append(deadComponent);
+        return applyConfigStyles(aliveComponent.append(deadComponent));
     }
 
-    private TextComponent getBoldAndStrikeThroughSpaceLine(int barLength, TextColor color) {
-        return Component.text(SPACE.repeat(barLength), color, TextDecoration.STRIKETHROUGH, TextDecoration.BOLD);
+    private TextComponent buildAliveComponent(int barLength) {
+        return Component.text(cfm.getStringValue(HEALTH_BAR_ALIVE_SYMBOL).repeat(barLength), cfm.getTextColor(HEALTH_BAR_ALIVE_COLOR));
     }
 
-    @EventHandler
+    private TextComponent buildDeadComponent(int barLength) {
+        return Component.text(cfm.getStringValue(HEALTH_BAR_DEAD_SYMBOL).repeat(barLength), cfm.getTextColor(HEALTH_BAR_DEAD_COLOR));
+    }
+
+    private Component applyConfigStyles(TextComponent healthBar) {
+        if (cfm.getBooleanValue(DefaultConfigValue.HEALTH_BAR_BOLD)) {
+            healthBar = healthBar.decorate(TextDecoration.BOLD);
+        }
+
+        if (cfm.getBooleanValue(HEALTH_BAR_STRIKETHROUGH)) {
+            healthBar = healthBar.decorate(TextDecoration.STRIKETHROUGH);
+        }
+
+        if (cfm.getBooleanValue(HEALTH_BAR_UNDERLINED)) {
+            healthBar = healthBar.decorate(TextDecoration.UNDERLINED);
+        }
+
+        return healthBar;
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
     public void displayHealthBar(EntityDamageEvent event) {
         if (!(event.getEntity() instanceof LivingEntity livingEntity)) return;
 
@@ -75,7 +101,7 @@ public class HealthBarListener implements Listener {
     }
 
     private int getTicksDuration() {
-        int displayDuration = configurationFileManager.getValue(DefaultConfigValue.HEALTH_BAR_DISPLAY_DURATION);
+        int displayDuration = cfm.getValue(DefaultConfigValue.HEALTH_BAR_DISPLAY_DURATION);
         return TICKS_PER_SECOND * Math.max(MIN_SECONDS, Math.min(displayDuration, MAX_SECONDS));
     }
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: damageindicator
-version: 1.1.8
+version: 1.1.9
 main: io.github.stealingdapenta.damageindicator.DamageIndicator
 author: StealingDaPenta
 description: The best Damage Indicator in the game!


### PR DESCRIPTION
- Fixed HP Bar display bug: now accurately displays up to date health;
- Added bar styles in the config: configurate your custom character, bold, underlined, strikethrough
- Added Name reset upon death: if an entity dies and at the moment of death the name was an hp bar: set the name back to the original name before dying. 